### PR TITLE
Make MonitorSetup's schedule default to model granularity

### DIFF
--- a/tests/helpers/test_monitor_helpers.py
+++ b/tests/helpers/test_monitor_helpers.py
@@ -2,10 +2,11 @@ import os
 
 from whylabs_toolkit.helpers.monitor_helpers import (
     delete_monitor,
-    get_analyzer_ids,
+    get_model_granularity,
     get_monitor_config
 )
 from whylabs_toolkit.helpers.utils import get_models_api
+from whylabs_toolkit.monitor.models import Granularity
 
 
 ORG_ID = os.environ["ORG_ID"]
@@ -88,6 +89,11 @@ class TestDeleteMonitor(BaseTestMonitor):
 
     def test_get_monitor(self) -> None:
         pass
+
+    def test_get_granularity(self) -> None:
+        granularity = get_model_granularity(org_id=ORG_ID, dataset_id=DATASET_ID)
+        assert granularity == Granularity.monthly
+
 
     def test_delete_monitor(self) -> None:
         delete_monitor(

--- a/tests/monitor/manager/test_manager.py
+++ b/tests/monitor/manager/test_manager.py
@@ -18,10 +18,7 @@ class TestModelManager(BaseTestMonitor):
     def manager(self, existing_monitor_setup: MonitorSetup) -> MonitorManager:
         mm = MonitorManager(setup=existing_monitor_setup)
         return mm
-    def test_get_granularity(self, manager: MonitorManager) -> None:
-        granularity = manager.get_granularity()
-        assert granularity == Granularity.monthly
-    
+
     def test_dump(self, manager: MonitorManager) -> None:
         document = manager.dump()
         assert isinstance(json.loads(document), Dict)

--- a/whylabs_toolkit/helpers/monitor_helpers.py
+++ b/whylabs_toolkit/helpers/monitor_helpers.py
@@ -56,9 +56,7 @@ def get_analyzers(monitor_id: str, org_id: Optional[str], dataset_id: Optional[s
 
 def get_model_granularity(org_id: str, dataset_id: str) -> Optional[Granularity]:
     api = get_models_api()
-    model_meta = api.get_model(
-        org_id=org_id, model_id=dataset_id
-    )
+    model_meta = api.get_model(org_id=org_id, model_id=dataset_id)
 
     time_period_to_gran = {
         "H": Granularity.hourly,
@@ -70,6 +68,7 @@ def get_model_granularity(org_id: str, dataset_id: str) -> Optional[Granularity]
     for key, value in time_period_to_gran.items():
         if key in model_meta["time_period"].value:
             return value
+    return None
 
 
 def delete_monitor(org_id: str, dataset_id: str, monitor_id: str) -> None:

--- a/whylabs_toolkit/helpers/monitor_helpers.py
+++ b/whylabs_toolkit/helpers/monitor_helpers.py
@@ -6,6 +6,7 @@ from whylabs_client.exceptions import NotFoundException
 
 from whylabs_toolkit.helpers.config import Config
 from whylabs_toolkit.helpers.utils import get_models_api
+from whylabs_toolkit.monitor.models import Granularity
 
 BASE_ENDPOINT = "https://api.whylabsapp.com"
 logger = logging.getLogger(__name__)
@@ -51,6 +52,24 @@ def get_analyzers(monitor_id: str, org_id: Optional[str], dataset_id: Optional[s
         return analyzers
     else:
         raise NotFoundException
+
+
+def get_model_granularity(org_id: str, dataset_id: str) -> Optional[Granularity]:
+    api = get_models_api()
+    model_meta = api.get_model(
+        org_id=org_id, model_id=dataset_id
+    )
+
+    time_period_to_gran = {
+        "H": Granularity.hourly,
+        "D": Granularity.daily,
+        "W": Granularity.weekly,
+        "M": Granularity.monthly,
+    }
+
+    for key, value in time_period_to_gran.items():
+        if key in model_meta["time_period"].value:
+            return value
 
 
 def delete_monitor(org_id: str, dataset_id: str, monitor_id: str) -> None:

--- a/whylabs_toolkit/monitor/manager/manager.py
+++ b/whylabs_toolkit/monitor/manager/manager.py
@@ -80,8 +80,7 @@ class MonitorManager:
             orgId=self._setup.credentials.org_id,
             datasetId=self._setup.credentials.dataset_id,
             granularity=get_model_granularity(
-                org_id=self._setup.credentials.org_id,
-                dataset_id=self._setup.credentials.dataset_id
+                org_id=self._setup.credentials.org_id, dataset_id=self._setup.credentials.dataset_id  # type: ignore
             ),
             analyzers=[self._setup.analyzer],
             monitors=[self._setup.monitor],

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -205,10 +205,11 @@ class MonitorSetup:
     def apply(self) -> None:
         monitor_mode = self.monitor_mode or DigestMode()
         actions = self._monitor_actions or []
-        self._analyzer_schedule = self._analyzer_schedule or FixedCadenceSchedule(cadence=get_model_granularity(
-            org_id=self.credentials.org_id,
-            dataset_id=self.credentials.dataset_id
-        ))
+        self._analyzer_schedule = self._analyzer_schedule or FixedCadenceSchedule(
+            cadence=get_model_granularity(
+                org_id=self.credentials.org_id, dataset_id=self.credentials.dataset_id  # type: ignore
+            )
+        )
 
         self.__set_monitor(monitor_mode=monitor_mode, monitor_actions=actions)
 

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -9,7 +9,7 @@ from whylabs_client.exceptions import NotFoundException
 from whylabs_toolkit.helpers.utils import get_models_api
 from whylabs_toolkit.monitor.models import *
 from whylabs_toolkit.monitor.manager.credentials import MonitorCredentials
-from whylabs_toolkit.helpers.monitor_helpers import get_analyzers, get_monitor
+from whylabs_toolkit.helpers.monitor_helpers import get_analyzers, get_monitor, get_model_granularity
 
 
 logging.basicConfig(level=logging.INFO)
@@ -205,7 +205,10 @@ class MonitorSetup:
     def apply(self) -> None:
         monitor_mode = self.monitor_mode or DigestMode()
         actions = self._monitor_actions or []
-        self._analyzer_schedule = self._analyzer_schedule or FixedCadenceSchedule(cadence=Cadence.daily)
+        self._analyzer_schedule = self._analyzer_schedule or FixedCadenceSchedule(cadence=get_model_granularity(
+            org_id=self.credentials.org_id,
+            dataset_id=self.credentials.dataset_id
+        ))
 
         self.__set_monitor(monitor_mode=monitor_mode, monitor_actions=actions)
 


### PR DESCRIPTION
- made `get_model_granularity` a helper on `helpers/monitor_helpers.py`
- moved the test to the proper location
- changed the default schedule for `MonitorSetup`