### PR TITLE
Fix: Auto switch dataset matrix

### DIFF
--- a/tests/monitor/manager/test_monitor_setup.py
+++ b/tests/monitor/manager/test_monitor_setup.py
@@ -121,3 +121,24 @@ def test_setup_with_group_of_columns(monitor_setup) -> None:
 def test_setup_with_wrong_group_column_type(monitor_setup) -> None:
     with pytest.raises(ValueError):
         monitor_setup.set_target_columns(columns=["group:inputs"])
+
+
+def test_dataset_matrix_is_auto_setup_if_model_metrics(monitor_setup):
+    monitor_setup.config = FixedThresholdsConfig(
+        metric=DatasetMetric.classification_accuracy,
+        lower=0.75
+    )
+    monitor_setup.apply()
+    
+    assert monitor_setup.target_matrix == DatasetMatrix()
+    
+    monitor_setup.config = FixedThresholdsConfig(
+        metric=SimpleColumnMetric.count_bool,
+        lower=0.75
+    )
+    monitor_setup.apply()
+    
+    assert isinstance(
+        monitor_setup.target_matrix,
+        ColumnMatrix
+    )

--- a/tests/monitor/manager/test_monitor_setup.py
+++ b/tests/monitor/manager/test_monitor_setup.py
@@ -130,7 +130,8 @@ def test_dataset_matrix_is_auto_setup_if_model_metrics(monitor_setup):
     )
     monitor_setup.apply()
     
-    assert monitor_setup.target_matrix == DatasetMatrix()
+    assert monitor_setup.target_matrix == DatasetMatrix(segments=[])
+    assert monitor_setup.analyzer.targetMatrix == DatasetMatrix(segments=[])
     
     monitor_setup.config = FixedThresholdsConfig(
         metric=SimpleColumnMetric.count_bool,
@@ -142,3 +143,9 @@ def test_dataset_matrix_is_auto_setup_if_model_metrics(monitor_setup):
         monitor_setup.target_matrix,
         ColumnMatrix
     )
+    
+    assert isinstance(
+        monitor_setup.analyzer.targetMatrix,
+        ColumnMatrix
+    )
+    

--- a/tests/monitor/manager/test_monitor_setup.py
+++ b/tests/monitor/manager/test_monitor_setup.py
@@ -52,10 +52,11 @@ def test_setup(monitor_setup):
 
 
 def test_set_target_matrix(monitor_setup):
-    monitor_setup.target_matrix = DatasetMatrix()
+    monitor_setup.target_matrix = ColumnMatrix(include=["some_specific_column"], segments=[])
     monitor_setup.apply()
 
-    assert not isinstance(monitor_setup.target_matrix, ColumnMatrix)
+    assert isinstance(monitor_setup.target_matrix, ColumnMatrix)
+    assert monitor_setup.analyzer.targetMatrix == ColumnMatrix(include=["some_specific_column"], segments=[])
 
 
 def test_set_and_exclude_columns_keep_state(monitor_setup):

--- a/tests/monitor/manager/test_monitor_setup.py
+++ b/tests/monitor/manager/test_monitor_setup.py
@@ -148,4 +148,21 @@ def test_dataset_matrix_is_auto_setup_if_model_metrics(monitor_setup):
         monitor_setup.analyzer.targetMatrix,
         ColumnMatrix
     )
+
+def test_apply_wont_change_monitor_columns(monitor_setup):
+    monitor_setup.set_target_columns(columns=["prediction_temperature", "temperature"])
+    monitor_setup.apply()
     
+    assert monitor_setup.analyzer.targetMatrix != ColumnMatrix(include=["*"] , exclude=[], segments=[])
+
+
+def test_apply_wont_erase_existing_preconfig(monitor_setup):
+    monitor_setup.config = FixedThresholdsConfig(
+        metric=DatasetMetric.classification_accuracy,
+        lower=0.75
+    )
+    
+    monitor_setup.target_matrix = DatasetMatrix(segments=[Segment(tags=[SegmentTag(key="segment_a", value="value_a")])])
+    
+    monitor_setup.apply()
+    assert monitor_setup.analyzer.targetMatrix == DatasetMatrix(segments=[Segment(tags=[SegmentTag(key="segment_a", value="value_a")])])

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -212,9 +212,14 @@ class MonitorSetup:
         self._target_matrix = self._target_matrix or ColumnMatrix(
             include=self._target_columns or ["*"], exclude=self._exclude_columns, segments=[]
         )
-        if self.analyzer:
-            if isinstance(self.analyzer.config.metric, DatasetMetric):
-                self._target_matrix = DatasetMatrix()
+
+    def __set_dataset_matrix_for_dataset_metric(self) -> None:
+        if isinstance(self.analyzer.config.metric, DatasetMetric):
+            self._target_matrix = DatasetMatrix()
+
+        elif self._target_matrix == DatasetMatrix() and not isinstance(self.analyzer.config.metric, DatasetMetric):
+            self._target_matrix = None
+            self.__configure_target_matrix()
 
     def apply(self) -> None:
         monitor_mode = self._monitor_mode or DigestMode()
@@ -229,3 +234,4 @@ class MonitorSetup:
 
         self.__configure_target_matrix()
         self.__set_analyzer()
+        self.__set_dataset_matrix_for_dataset_metric()

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -185,6 +185,9 @@ class MonitorSetup:
         )
 
     def __set_analyzer(self) -> None:
+        self.__configure_target_matrix()
+        self.__set_dataset_matrix_for_dataset_metric()
+
         self.analyzer = Analyzer(
             id=self.credentials.analyzer_id,
             displayName=self.credentials.analyzer_id,
@@ -214,12 +217,16 @@ class MonitorSetup:
         )
 
     def __set_dataset_matrix_for_dataset_metric(self) -> None:
-        if isinstance(self.analyzer.config.metric, DatasetMetric):
-            self._target_matrix = DatasetMatrix()
+        if isinstance(self._analyzer_config.metric, DatasetMetric):
+            self._target_matrix = DatasetMatrix(segments=[])
+            return None
 
-        elif self._target_matrix == DatasetMatrix() and not isinstance(self.analyzer.config.metric, DatasetMetric):
+        elif isinstance(self._target_matrix, DatasetMatrix) and not isinstance(
+            self._analyzer_config.metric, DatasetMetric
+        ):
             self._target_matrix = None
             self.__configure_target_matrix()
+            return None
 
     def apply(self) -> None:
         monitor_mode = self._monitor_mode or DigestMode()
@@ -232,6 +239,4 @@ class MonitorSetup:
 
         self.__set_monitor(monitor_mode=monitor_mode, monitor_actions=actions)
 
-        self.__configure_target_matrix()
         self.__set_analyzer()
-        self.__set_dataset_matrix_for_dataset_metric()

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -186,7 +186,7 @@ class MonitorSetup:
 
     def __set_analyzer(self) -> None:
         self.__configure_target_matrix()
-        
+
         self.__set_dataset_matrix_for_dataset_metric()
 
         self.analyzer = Analyzer(
@@ -218,16 +218,19 @@ class MonitorSetup:
         )
 
     def __set_dataset_matrix_for_dataset_metric(self) -> None:
-        if isinstance(self._analyzer_config.metric, DatasetMetric) and isinstance(self._target_matrix, ColumnMatrix):
-            self._target_matrix = DatasetMatrix(segments=[])
-            return None
+        if self._analyzer_config:
+            if isinstance(self._analyzer_config.metric, DatasetMetric) and isinstance(
+                self._target_matrix, ColumnMatrix
+            ):
+                self._target_matrix = DatasetMatrix(segments=[])
+                return None
 
-        elif isinstance(self._target_matrix, DatasetMatrix) and not isinstance(
-            self._analyzer_config.metric, DatasetMetric
-        ):
-            self._target_matrix = None
-            self.__configure_target_matrix()
-            return None
+            elif isinstance(self._target_matrix, DatasetMatrix) and not isinstance(
+                self._analyzer_config.metric, DatasetMetric
+            ):
+                self._target_matrix = None
+                self.__configure_target_matrix()
+                return None
 
     def apply(self) -> None:
         monitor_mode = self._monitor_mode or DigestMode()

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -186,6 +186,7 @@ class MonitorSetup:
 
     def __set_analyzer(self) -> None:
         self.__configure_target_matrix()
+        
         self.__set_dataset_matrix_for_dataset_metric()
 
         self.analyzer = Analyzer(
@@ -217,7 +218,7 @@ class MonitorSetup:
         )
 
     def __set_dataset_matrix_for_dataset_metric(self) -> None:
-        if isinstance(self._analyzer_config.metric, DatasetMetric):
+        if isinstance(self._analyzer_config.metric, DatasetMetric) and isinstance(self._target_matrix, ColumnMatrix):
             self._target_matrix = DatasetMatrix(segments=[])
             return None
 


### PR DESCRIPTION
We had a behavior where it should automatically set `DatasetMatrix` for cases when `Analyzer.config`'s metric was of type `DatasetMetric`. But there was a bug that that was set after `__set_analyzer()`, so it changed `MonitorSetup._target_matrix` but not `MonitorSetup.analyzer.targetMatrix`.  