### PR TITLE
Feature: allow monitors to be triggered eagerly

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.5
+current_version = 0.0.6-dev0
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.6-dev0
+current_version = 0.0.6
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whylabs-toolkit"
-version = "0.0.6-dev0"
+version = "0.0.6"
 description = "Whylabs CLI and Helpers package."
 authors = ["Anthony Naddeo <anthony.naddeo@gmail.com>", "Murilo Mendonca <murilommen@gmail.com>"]
 license = "Apache-2.0 license"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whylabs-toolkit"
-version = "0.0.5"
+version = "0.0.6-dev0"
 description = "Whylabs CLI and Helpers package."
 authors = ["Anthony Naddeo <anthony.naddeo@gmail.com>", "Murilo Mendonca <murilommen@gmail.com>"]
 license = "Apache-2.0 license"


### PR DESCRIPTION
A customer requested a way to set `allowPartialTargetBatches` with whylabs-toolkit. This PR solves that by adding a `eager` flag to `MonitorManager`. 
Typical workflow is as follows:

```python
setup = MonitorSetup(...)
setup.config = ...
setup.apply()

mm = MonitorManager(setup, eager=True)
mm.save()
```
Which will make the `allowPartialTargetBatches` flag to be True on the document.
For the next times they want to interact with the monitor but not mess with the `eager` flag, it will not be changed.