### PR TITLE
Refac: Add warnings on mismatch between metric and matrix

### DIFF
--- a/tests/monitor/manager/test_monitor_setup.py
+++ b/tests/monitor/manager/test_monitor_setup.py
@@ -215,4 +215,4 @@ def test_dataset_metrics_are_warned_on_setup(caplog):
         assert monitor_setup.target_matrix.segments == [Segment(tags=[
             SegmentTag(key="Segment_Dataset", value="Training_PCS_tags")
         ])]
-        assert "ColumnMatrix is not fit for a config metric that is a DatasetMetric." in caplog.text
+        assert "ColumnMatrix is not configurable with a DatasetMetric" in caplog.text

--- a/tests/monitor/manager/test_monitor_setup.py
+++ b/tests/monitor/manager/test_monitor_setup.py
@@ -166,3 +166,53 @@ def test_apply_wont_erase_existing_preconfig(monitor_setup):
     
     monitor_setup.apply()
     assert monitor_setup.analyzer.targetMatrix == DatasetMatrix(segments=[Segment(tags=[SegmentTag(key="segment_a", value="value_a")])])
+
+
+def test_target_matrix_is_warned_on_setup(caplog):
+    with caplog.at_level(level="WARNING"):
+        monitor_setup = MonitorSetup(
+            monitor_id='test-target-matrix'
+        )
+
+        monitor_setup.config = DriftConfig(
+            metric=ComplexMetrics.frequent_items,
+            threshold=0.7,
+            baseline=TrailingWindowBaseline(size=7),
+        )
+
+        # Set wrong matrix with segments
+        monitor_setup.target_matrix = DatasetMatrix(
+            segments=[Segment(tags=[SegmentTag(key="Segment_Dataset", value="Training_PCS_tags")])])
+
+        monitor_setup.apply()
+
+
+        assert isinstance(monitor_setup.target_matrix, ColumnMatrix)
+        assert monitor_setup.target_matrix.segments == [Segment(tags=[
+            SegmentTag(key="Segment_Dataset", value="Training_PCS_tags")
+        ])]
+        assert "Setting a DatasetMatrix requires a DatasetMetric to be used" in caplog.text
+
+def test_dataset_metrics_are_warned_on_setup(caplog):
+    with caplog.at_level(level="WARNING"):
+        monitor_setup = MonitorSetup(
+            monitor_id='test-target-matrix'
+        )
+
+        monitor_setup.config = StddevConfig(
+            metric=DatasetMetric.classification_accuracy,
+            maxUpperThreshold=7,
+            baseline=TrailingWindowBaseline(size=7),
+        )
+
+        # Set wrong matrix with segments
+        monitor_setup.target_matrix = ColumnMatrix(
+            segments=[Segment(tags=[SegmentTag(key="Segment_Dataset", value="Training_PCS_tags")])])
+
+        monitor_setup.apply()
+        
+        assert isinstance(monitor_setup.target_matrix, DatasetMatrix)
+        assert monitor_setup.target_matrix.segments == [Segment(tags=[
+            SegmentTag(key="Segment_Dataset", value="Training_PCS_tags")
+        ])]
+        assert "ColumnMatrix is not fit for a config metric that is a DatasetMetric." in caplog.text

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -185,6 +185,7 @@ class MonitorSetup:
             self._target_matrix = self._target_matrix or ColumnMatrix(
                 include=self._target_columns, exclude=self._exclude_columns, segments=[]
             )
+            self._target_matrix.include = self._target_columns
 
     def exclude_target_columns(self, columns: List[str]) -> None:
         if self._validate_columns_input(columns=columns):
@@ -192,6 +193,7 @@ class MonitorSetup:
             self._target_matrix = self._target_matrix or ColumnMatrix(
                 include=self._target_columns, exclude=self._exclude_columns, segments=[]
             )
+            self._target_matrix.exclude = self._exclude_columns
 
     def set_fixed_dates_baseline(self, start_date: datetime, end_date: datetime) -> None:
         if not start_date.tzinfo:

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -185,7 +185,8 @@ class MonitorSetup:
             self._target_matrix = self._target_matrix or ColumnMatrix(
                 include=self._target_columns, exclude=self._exclude_columns, segments=[]
             )
-            self._target_matrix.include = self._target_columns
+            if isinstance(self._target_matrix, ColumnMatrix):
+                self._target_matrix.include = self._target_columns
 
     def exclude_target_columns(self, columns: List[str]) -> None:
         if self._validate_columns_input(columns=columns):
@@ -193,7 +194,8 @@ class MonitorSetup:
             self._target_matrix = self._target_matrix or ColumnMatrix(
                 include=self._target_columns, exclude=self._exclude_columns, segments=[]
             )
-            self._target_matrix.exclude = self._exclude_columns
+            if isinstance(self._target_matrix, ColumnMatrix):
+                self._target_matrix.exclude = self._target_columns
 
     def set_fixed_dates_baseline(self, start_date: datetime, end_date: datetime) -> None:
         if not start_date.tzinfo:

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -246,8 +246,7 @@ class MonitorSetup:
                 self._target_matrix, ColumnMatrix
             ):
                 logger.warning(
-                    "ColumnMatrix is not configurable with a DatasetMetric."
-                    "Changing it to DatasetMatrix instead"
+                    "ColumnMatrix is not configurable with a DatasetMetric." "Changing it to DatasetMatrix instead"
                 )
                 self._target_matrix = DatasetMatrix(segments=self._target_matrix.segments)
                 return None

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -246,8 +246,8 @@ class MonitorSetup:
                 self._target_matrix, ColumnMatrix
             ):
                 logger.warning(
-                    "ColumnMatrix is not fit for a config metric that is a DatasetMetric."
-                    "Changing it to an empty DatasetMatrix instead"
+                    "ColumnMatrix is not configurable with a DatasetMetric."
+                    "Changing it to DatasetMatrix instead"
                 )
                 self._target_matrix = DatasetMatrix(segments=self._target_matrix.segments)
                 return None

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -195,7 +195,7 @@ class MonitorSetup:
                 include=self._target_columns, exclude=self._exclude_columns, segments=[]
             )
             if isinstance(self._target_matrix, ColumnMatrix):
-                self._target_matrix.exclude = self._target_columns
+                self._target_matrix.exclude = self._exclude_columns
 
     def set_fixed_dates_baseline(self, start_date: datetime, end_date: datetime) -> None:
         if not start_date.tzinfo:


### PR DESCRIPTION
When defining a Dataset-level metric, you can't also setup a ColumnMatrix and vice-versa. This was already taken care of by the toolkit, but with two missing things:
- Segments were lost, even if defined on the specific TargetMatrix
- Nothing was warned to the user about it

This PR brings both of these to the codebase