### PR TITLE
Feature: add private_endpoint optional config

### DIFF
--- a/tests/helpers/test_config.py
+++ b/tests/helpers/test_config.py
@@ -14,3 +14,5 @@ def test_setup_with_private_endpoint():
     models_api = get_models_api()
     
     assert models_api.api_client.configuration.host == "http://private.com"
+    
+    del os.environ["WHYLABS_PRIVATE_API_ENDPOINT"]

--- a/tests/helpers/test_config.py
+++ b/tests/helpers/test_config.py
@@ -1,0 +1,16 @@
+import os
+
+from whylabs_toolkit.helpers.config import Config
+from whylabs_toolkit.helpers.models import get_models_api
+
+
+def test_setup_with_private_endpoint():
+    os.environ["WHYLABS_PRIVATE_API_ENDPOINT"] = "http://private.com"
+    
+    api_endpoint = Config().get_whylabs_host()
+    
+    assert api_endpoint == "http://private.com"
+    
+    models_api = get_models_api()
+    
+    assert models_api.api_client.configuration.host == "http://private.com"

--- a/whylabs_toolkit/helpers/config.py
+++ b/whylabs_toolkit/helpers/config.py
@@ -1,7 +1,6 @@
 import os
 import logging
 from enum import Enum
-from urllib.parse import urlparse
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -20,12 +19,12 @@ class Config:
         return Validations.require(ConfigVars.WHYLABS_API_KEY)
 
     def get_whylabs_host(self) -> str:
-        _private_api_endpoint = Validations.get_or_default(ConfigVars.WHYLABS_PRIVATE_API_ENDPOINT) 
+        _private_api_endpoint = Validations.get_or_default(ConfigVars.WHYLABS_PRIVATE_API_ENDPOINT)
         logger.debug(f"Using private API endpoint: {_private_api_endpoint}")
         _public_api_endpoint = Validations.get_or_default(ConfigVars.WHYLABS_HOST)
 
         return _private_api_endpoint or _public_api_endpoint
-        
+
     def get_default_org_id(self) -> str:
         return Validations.require(ConfigVars.ORG_ID)
 

--- a/whylabs_toolkit/helpers/config.py
+++ b/whylabs_toolkit/helpers/config.py
@@ -20,10 +20,10 @@ class Config:
 
     def get_whylabs_host(self) -> str:
         _private_api_endpoint = Validations.get_or_default(ConfigVars.WHYLABS_PRIVATE_API_ENDPOINT)
-        logger.debug(f"Using private API endpoint: {_private_api_endpoint}")
-        _public_api_endpoint = Validations.get_or_default(ConfigVars.WHYLABS_HOST)
-
-        return _private_api_endpoint or _public_api_endpoint
+        if _private_api_endpoint and isinstance(_private_api_endpoint, str):
+            logger.debug(f"Using private API endpoint: {_private_api_endpoint}")
+            return _private_api_endpoint
+        return Validations.get_or_default(ConfigVars.WHYLABS_HOST)
 
     def get_default_org_id(self) -> str:
         return Validations.require(ConfigVars.ORG_ID)

--- a/whylabs_toolkit/helpers/config.py
+++ b/whylabs_toolkit/helpers/config.py
@@ -1,5 +1,10 @@
 import os
+import logging
 from enum import Enum
+from urllib.parse import urlparse
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class ConfigVars(Enum):
@@ -7,6 +12,7 @@ class ConfigVars(Enum):
     DATASET_ID = 2
     WHYLABS_API_KEY = 3
     WHYLABS_HOST = "https://api.whylabsapp.com"
+    WHYLABS_PRIVATE_API_ENDPOINT = 5
 
 
 class Config:
@@ -14,8 +20,12 @@ class Config:
         return Validations.require(ConfigVars.WHYLABS_API_KEY)
 
     def get_whylabs_host(self) -> str:
-        return Validations.get_or_default(ConfigVars.WHYLABS_HOST)
+        _private_api_endpoint = Validations.get_or_default(ConfigVars.WHYLABS_PRIVATE_API_ENDPOINT) 
+        logger.debug(f"Using private API endpoint: {_private_api_endpoint}")
+        _public_api_endpoint = Validations.get_or_default(ConfigVars.WHYLABS_HOST)
 
+        return _private_api_endpoint or _public_api_endpoint
+        
     def get_default_org_id(self) -> str:
         return Validations.require(ConfigVars.ORG_ID)
 


### PR DESCRIPTION
Some WhyLabs customers need to access our API through a private link. 
This PR adds that without breaking the existing definitions.