### PR TITLE
Adding delete analyzer result

### DIFF
--- a/tests/helpers/test_dataset_profiles.py
+++ b/tests/helpers/test_dataset_profiles.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from unittest.mock import patch, Mock
 
 import pytest
 
@@ -74,4 +75,33 @@ def test_delete_profiles_raises_if_other_format_is_passed():
             dataset_id = os.environ["DATASET_ID"], 
             org_id=os.environ["ORG_ID"]
         )
+
+@patch('whylabs_toolkit.helpers.dataset_profiles.get_dataset_profile_api')
+def test_delete_profiles_calls_delete_analyzer_results(mock_get_api):
+    mock_call = Mock()
+    mock_get_api.return_value = mock_call
+    mock_call.delete_dataset_profiles = Mock()
+    mock_call.delete_analyzer_results = Mock()
     
+    
+    
+    delete_all_profiles_for_period(
+        start=int(datetime(2023,7,5).timestamp()*1000.0), 
+        end=int(datetime(2023,7,6).timestamp()*1000.0), 
+        dataset_id = os.environ["DATASET_ID"], 
+        org_id=os.environ["ORG_ID"]
+    )
+    
+    mock_call.delete_dataset_profiles.assert_called_with(
+        org_id=os.environ["ORG_ID"], 
+        dataset_id=os.environ["DATASET_ID"], 
+        profile_start_timestamp=int(datetime(2023,7,5).timestamp()*1000.0), 
+        profile_end_timestamp=int(datetime(2023,7,6).timestamp()*1000.0)
+    )
+    
+    mock_call.delete_analyzer_results.assert_called_with(
+        org_id=os.environ["ORG_ID"], 
+        dataset_id=os.environ["DATASET_ID"], 
+        start_timestamp=int(datetime(2023,7,5).timestamp()*1000.0), 
+        end_timestamp=int(datetime(2023,7,6).timestamp()*1000.0)
+    )

--- a/whylabs_toolkit/helpers/dataset_profiles.py
+++ b/whylabs_toolkit/helpers/dataset_profiles.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Optional, Union, Tuple
+from typing import Optional, Union
 
 from whylabs_client.api.dataset_profile_api import DeleteDatasetProfilesResponse, DeleteAnalyzerResultsResponse
 
@@ -41,7 +41,7 @@ def delete_all_profiles_for_period(
     config: Config = Config(),
     org_id: Optional[str] = None,
     dataset_id: Optional[str] = None,
-) -> Tuple[DeleteDatasetProfilesResponse, DeleteAnalyzerResultsResponse]:
+) -> DeleteDatasetProfilesResponse:
     api = get_dataset_profile_api()
 
     profile_start_timestamp = process_date_input(date_input=start)
@@ -57,15 +57,15 @@ def delete_all_profiles_for_period(
         profile_end_timestamp=profile_end_timestamp,
     )
     logger.info(f"Scheduled deletion for profiles on {dataset_id} for {org_id}")
-    
+
     api.delete_analyzer_results(
         org_id=org_id,
         dataset_id=dataset_id,
         start_timestamp=profile_start_timestamp,
         end_timestamp=profile_end_timestamp,
     )
-    
+
     logger.info("Deleted analyzer results for the same timestamps as the profiles")
     logger.info(f"NOTE: Profile deletion happens every full hour on WhyLabs")
-    
+
     return result_profiles

--- a/whylabs_toolkit/helpers/dataset_profiles.py
+++ b/whylabs_toolkit/helpers/dataset_profiles.py
@@ -1,13 +1,14 @@
-# from whylabs_client.api.
+import logging
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 
-from whylabs_client.api.dataset_profile_api import DeleteDatasetProfilesResponse
+from whylabs_client.api.dataset_profile_api import DeleteDatasetProfilesResponse, DeleteAnalyzerResultsResponse
 
 from whylabs_toolkit.helpers.utils import get_dataset_profile_api
 from whylabs_toolkit.helpers.config import Config
 
 date_or_millis = Union[datetime, int]
+logger = logging.getLogger(__name__)
 
 
 def validate_timestamp_in_millis(epoch_milliseconds: int) -> bool:
@@ -40,7 +41,7 @@ def delete_all_profiles_for_period(
     config: Config = Config(),
     org_id: Optional[str] = None,
     dataset_id: Optional[str] = None,
-) -> DeleteDatasetProfilesResponse:
+) -> Tuple[DeleteDatasetProfilesResponse, DeleteAnalyzerResultsResponse]:
     api = get_dataset_profile_api()
 
     profile_start_timestamp = process_date_input(date_input=start)
@@ -49,11 +50,22 @@ def delete_all_profiles_for_period(
     org_id = org_id or config.get_default_org_id()
     dataset_id = dataset_id or config.get_default_dataset_id()
 
-    result: DeleteDatasetProfilesResponse = api.delete_dataset_profiles(
+    result_profiles: DeleteDatasetProfilesResponse = api.delete_dataset_profiles(
         org_id=org_id,
         dataset_id=dataset_id,
         profile_start_timestamp=profile_start_timestamp,
         profile_end_timestamp=profile_end_timestamp,
     )
-
-    return result
+    logger.info(f"Scheduled deletion for profiles on {dataset_id} for {org_id}")
+    
+    api.delete_analyzer_results(
+        org_id=org_id,
+        dataset_id=dataset_id,
+        start_timestamp=profile_start_timestamp,
+        end_timestamp=profile_end_timestamp,
+    )
+    
+    logger.info("Deleted analyzer results for the same timestamps as the profiles")
+    logger.info(f"NOTE: Profile deletion happens every full hour on WhyLabs")
+    
+    return result_profiles


### PR DESCRIPTION
Through a WhyLabs user request, it is desirable that `delete_profiles` automatically deletes analyzer results as well.
also, this PR adds a few logging messages to inform the user that the profiles will be scheduled for deletion and not immediately deleted.