### PR TITLE
FR: add delay duration as property

### DIFF
--- a/tests/monitor/manager/test_monitor_setup.py
+++ b/tests/monitor/manager/test_monitor_setup.py
@@ -256,6 +256,17 @@ def test_dataset_matrix_if_metric_is_missing_datapoint(monitor_setup) -> None:
     assert isinstance(monitor_setup.analyzer.targetMatrix, DatasetMatrix)
 
 
+def test_dataset_matrix_if_metric_is_secondsSinceLastUpload(monitor_setup) -> None:
+    monitor_setup.config = FixedThresholdsConfig(
+        upper=0,
+        metric="secondsSinceLastUpload"
+    )
+    monitor_setup.apply()
+    
+    assert monitor_setup.analyzer.config.metric == "secondsSinceLastUpload"
+    assert isinstance(monitor_setup.analyzer.targetMatrix, DatasetMatrix)
+
+
 def test_set_non_iso_data_readiness_raises(monitor_setup) -> None:
     monitor_setup.data_readiness_duration = "P1DT18H"
     monitor_setup.apply()

--- a/tests/monitor/manager/test_monitor_setup.py
+++ b/tests/monitor/manager/test_monitor_setup.py
@@ -241,3 +241,25 @@ def test_dataset_metrics_are_warned_on_setup(caplog):
             SegmentTag(key="Segment_Dataset", value="Training_PCS_tags")
         ])]
         assert "ColumnMatrix is not configurable with a DatasetMetric" in caplog.text
+
+
+def test_dataset_matrix_if_metric_is_missing_datapoint(monitor_setup) -> None:
+    monitor_setup.config = FixedThresholdsConfig(
+        upper=0,
+        metric="missingDataPoint"
+    )
+    monitor_setup.data_readiness_duration = "P1DT18H"
+    monitor_setup.apply()
+    
+    assert monitor_setup.analyzer.config.metric == "missingDataPoint"
+    assert monitor_setup.analyzer.dataReadinessDuration == "P1DT18H"
+    assert isinstance(monitor_setup.analyzer.targetMatrix, DatasetMatrix)
+
+
+def test_set_non_iso_data_readiness_raises(monitor_setup) -> None:
+    monitor_setup.data_readiness_duration = "P1DT18H"
+    monitor_setup.apply()
+    
+    with pytest.raises(ValueError):
+        monitor_setup.data_readiness_duration = "Some non-conformant string"
+    

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -1,3 +1,4 @@
+import re
 import logging
 from datetime import datetime, timezone
 from typing import Optional, List, Union, Any
@@ -147,6 +148,22 @@ class MonitorSetup:
     @mode.setter
     def mode(self, mode: Union[EveryAnomalyMode, DigestMode]) -> None:
         self._monitor_mode = mode
+    
+    @property
+    def data_readiness_duration(self) -> Optional[str]:
+        return self._data_readiness_duration
+        
+    @data_readiness_duration.setter
+    def data_readiness_duration(self, delay_duration: str) -> None:
+        if self._validate_delay_duration(delay=delay_duration) is False:
+            raise ValueError(f"{delay_duration} does not respect ISO 8601 format")
+        self._data_readiness_duration = delay_duration
+
+
+    def _validate_delay_duration(delay: str) -> bool:
+        pattern = r'^P(\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$'
+        return bool(re.match(pattern, delay))
+
 
     def _validate_columns_input(self, columns: List[str]) -> bool:
         if type(columns) != list or not all(isinstance(column, str) for column in columns):
@@ -216,6 +233,7 @@ class MonitorSetup:
             id=self.credentials.analyzer_id,
             displayName=self.credentials.analyzer_id,
             targetMatrix=self._target_matrix,
+            dataReadinessDuration=self._data_readiness_duration,
             tags=[],
             schedule=self._analyzer_schedule,
             config=self._analyzer_config,

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -46,7 +46,7 @@ class MonitorSetup:
         self._target_columns: Optional[List[str]] = []
         self._exclude_columns: Optional[List[str]] = []
         self._data_readiness_duration: Optional[str] = None
-        
+
         self._prefill_properties()
 
     def _check_if_monitor_exists(self) -> Any:
@@ -150,22 +150,20 @@ class MonitorSetup:
     @mode.setter
     def mode(self, mode: Union[EveryAnomalyMode, DigestMode]) -> None:
         self._monitor_mode = mode
-    
+
     @property
     def data_readiness_duration(self) -> Optional[str]:
         return self._data_readiness_duration
-        
+
     @data_readiness_duration.setter
     def data_readiness_duration(self, delay_duration: str) -> None:
         if self._validate_delay_duration(delay_duration) is False:
             raise ValueError(f"{delay_duration} does not respect ISO 8601 format")
         self._data_readiness_duration = delay_duration
 
-
     def _validate_delay_duration(self, delay: str) -> bool:
-        pattern = r'^P(\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$'
+        pattern = r"^P(\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$"
         return bool(re.match(pattern, delay))
-
 
     def _validate_columns_input(self, columns: List[str]) -> bool:
         if type(columns) != list or not all(isinstance(column, str) for column in columns):
@@ -267,12 +265,11 @@ class MonitorSetup:
                 self._target_matrix, ColumnMatrix
             ):
                 logger.warning(
-                    "ColumnMatrix is not configurable with a DatasetMetric." 
-                    "Changing it to DatasetMatrix instead"
+                    "ColumnMatrix is not configurable with a DatasetMetric." "Changing it to DatasetMatrix instead"
                 )
                 self._target_matrix = DatasetMatrix(segments=self._target_matrix.segments)
                 return None
-            
+
             elif isinstance(self._target_matrix, DatasetMatrix) and not isinstance(
                 self._analyzer_config.metric, DatasetMetric
             ):
@@ -288,17 +285,19 @@ class MonitorSetup:
                 return None
 
     def __set_dataset_matrix_for_missing_data_metric(self) -> None:
-        if isinstance(self._analyzer_config, FixedThresholdsConfig) \
-            and self._analyzer_config.metric == "missingDataPoint" \
-            and isinstance(self._target_matrix, ColumnMatrix):
-            
+        if (
+            isinstance(self._analyzer_config, FixedThresholdsConfig)
+            and self._analyzer_config.metric == "missingDataPoint"
+            and isinstance(self._target_matrix, ColumnMatrix)
+        ):
+
             logger.warning(
                 "Missing data point needs to be set with target_matrix of type DatasetMatrix"
                 "Changing to DatasetMatrix now."
             )
             self._target_matrix = DatasetMatrix(segments=self._target_matrix.segments)
             return None
-    
+
     def apply(self) -> None:
         monitor_mode = self._monitor_mode or DigestMode()
         actions = self._monitor_actions or []

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -298,6 +298,18 @@ class MonitorSetup:
             self._target_matrix = DatasetMatrix(segments=self._target_matrix.segments)
             return None
 
+        if (
+            isinstance(self._analyzer_config, FixedThresholdsConfig)
+            and self._analyzer_config.metric == "secondsSinceLastUpload"
+            and isinstance(self._target_matrix, ColumnMatrix)
+        ):
+            logger.warning(
+                "secondsSinceLastUpload needs to be set with target_matrix of type DatasetMatrix"
+                "Changing to DatasetMatrix now."
+            )
+            self._target_matrix = DatasetMatrix(segments=self._target_matrix.segments)
+            return None
+
     def apply(self) -> None:
         monitor_mode = self._monitor_mode or DigestMode()
         actions = self._monitor_actions or []


### PR DESCRIPTION
This PR adds `data_readiness_duration` as an actual property to the `MonitorSetup` object, which will allow users to setup a monitor for "missingDataPoint" with a delay duration, which will guarantee that the monitor for missing data is not run at the top of the hour for each ingestion period (ie: a delay to 00:00 UTC for daily models).

Changes description:
- add `data_readiness_duration` as property
- change the `target_matrix` property to `DatasetMatrix` if it identifies `missingDataPoint` as the metric
- validates if the `data_readiness_duration` is conformant with the ISO rule using regex 

PS: In the future, we need to have a proper object for "missingDataPoint" metric, but I'd rather wait until we centralize the monitor schema to do that once and properly on the right place.