### PR TITLE
Add support for constraint analyzer tags

### DIFF
--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 TAG_ANALYZER_CONSTRAINT = "whylabs.constraint"
 
+
 class MonitorSetup:
     def __init__(self, monitor_id: str, dataset_id: Optional[str] = None, config: Config = Config()) -> None:
 
@@ -162,11 +163,11 @@ class MonitorSetup:
 
     @is_constraint.setter
     def is_constraint(self, is_constraint: bool) -> None:
-        if (self._analyzer_config is None):
+        if self._analyzer_config is None:
             raise ValueError("Config must first be set")
         tags = set(self._analyzer_tags or [])
-        if (is_constraint):
-            if (not isinstance(self._analyzer_config, (FixedThresholdsConfig))):
+        if is_constraint:
+            if not isinstance(self._analyzer_config, (FixedThresholdsConfig)):
                 raise ValueError("Constraint can only be set with FixedThresholdsConfig")
             tags.add(TAG_ANALYZER_CONSTRAINT)
         else:

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -159,7 +159,7 @@ class MonitorSetup:
 
     @property
     def is_constraint(self) -> Optional[bool]:
-        return not (self._analyzer_tags is None) and TAG_ANALYZER_CONSTRAINT in self._analyzer_tags
+        return self._analyzer_tags is not None and TAG_ANALYZER_CONSTRAINT in self._analyzer_tags
 
     @is_constraint.setter
     def is_constraint(self, is_constraint: bool) -> None:

--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -16,6 +16,7 @@ from whylabs_toolkit.helpers.config import Config
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+TAG_ANALYZER_CONSTRAINT = "whylabs.constraint"
 
 class MonitorSetup:
     def __init__(self, monitor_id: str, dataset_id: Optional[str] = None, config: Config = Config()) -> None:
@@ -45,6 +46,8 @@ class MonitorSetup:
         ] = None
         self._target_columns: Optional[List[str]] = []
         self._exclude_columns: Optional[List[str]] = []
+        self._monitor_tags: Optional[List[str]] = []
+        self._analyzer_tags: Optional[List[str]] = []
         self._data_readiness_duration: Optional[str] = None
 
         self._prefill_properties()
@@ -82,10 +85,12 @@ class MonitorSetup:
         if self.monitor:
             self._monitor_mode = self.monitor.mode
             self._monitor_actions = self.monitor.actions
+            self._monitor_tags = self.monitor.tags
         if self.analyzer:
             self._analyzer_schedule = self.analyzer.schedule
             self._target_matrix = self.analyzer.targetMatrix
             self._analyzer_config = self.analyzer.config
+            self._analyzer_tags = self.analyzer.tags
 
     @property
     def schedule(self) -> Optional[Union[CronSchedule, FixedCadenceSchedule]]:
@@ -150,6 +155,23 @@ class MonitorSetup:
     @mode.setter
     def mode(self, mode: Union[EveryAnomalyMode, DigestMode]) -> None:
         self._monitor_mode = mode
+
+    @property
+    def is_constraint(self) -> Optional[bool]:
+        return not (self._analyzer_tags is None) and TAG_ANALYZER_CONSTRAINT in self._analyzer_tags
+
+    @is_constraint.setter
+    def is_constraint(self, is_constraint: bool) -> None:
+        if (self._analyzer_config is None):
+            raise ValueError("Config must first be set")
+        tags = set(self._analyzer_tags or [])
+        if (is_constraint):
+            if (not isinstance(self._analyzer_config, (FixedThresholdsConfig))):
+                raise ValueError("Constraint can only be set with FixedThresholdsConfig")
+            tags.add(TAG_ANALYZER_CONSTRAINT)
+        else:
+            tags.discard(TAG_ANALYZER_CONSTRAINT)
+        self._analyzer_tags = list(tags)
 
     @property
     def data_readiness_duration(self) -> Optional[str]:
@@ -235,7 +257,7 @@ class MonitorSetup:
             displayName=self.credentials.analyzer_id,
             targetMatrix=self._target_matrix,
             dataReadinessDuration=self._data_readiness_duration,
-            tags=[],
+            tags=self._analyzer_tags,
             schedule=self._analyzer_schedule,
             config=self._analyzer_config,
         )
@@ -247,7 +269,7 @@ class MonitorSetup:
             id=self.credentials.monitor_id,
             disabled=False,
             displayName=self.credentials.monitor_id,
-            tags=[],
+            tags=self._monitor_tags,
             analyzerIds=[self.credentials.analyzer_id],
             schedule=ImmediateSchedule(),
             mode=monitor_mode,

--- a/whylabs_toolkit/monitor/models/analyzer/analyzer.py
+++ b/whylabs_toolkit/monitor/models/analyzer/analyzer.py
@@ -21,6 +21,7 @@ from .algorithms import (
 )
 from .targets import ColumnMatrix, DatasetMatrix
 
+
 class Analyzer(NoExtrasBaseModel):
     """Configuration for running an analysis.
 

--- a/whylabs_toolkit/monitor/models/analyzer/analyzer.py
+++ b/whylabs_toolkit/monitor/models/analyzer/analyzer.py
@@ -21,7 +21,6 @@ from .algorithms import (
 )
 from .targets import ColumnMatrix, DatasetMatrix
 
-
 class Analyzer(NoExtrasBaseModel):
     """Configuration for running an analysis.
 


### PR DESCRIPTION
Constraints in the monitor configuration are represented as analyzers (currently only FixedThreshold analyzer) with the the `whylabs.constraint` tag.

This adds support for defining constraints in `MonitorSetup`

Example:
```
from whylabs_toolkit.monitor.models import *
from whylabs_toolkit.monitor import MonitorSetup
from whylabs_toolkit.monitor import MonitorManager 

monitor_setup = MonitorSetup(monitor_id="courageous-firebrick-tiger-3073")
manager = MonitorManager(setup=monitor_setup)
monitor_setup.is_constraint = True
monitor_setup.apply()
manager.save()
```

This configures the analyzer:
```
{
            "id": "courageous-firebrick-tiger-3073-analyzer",
            "displayName": "courageous-firebrick-tiger-3073-analyzer",
            "tags": [
                "whylabs.constraint"
            ],
            "schedule": {
                "type": "fixed",
                "cadence": "daily"
            },
            "targetMatrix": {
                "segments": [],
                "type": "dataset"
            },
            "config": {
                "metric": "secondsSinceLastUpload",
                "type": "fixed",
                "upper": 86400
            },
            "metadata": {
                "schemaVersion": 1,
                "author": "user_904...",
                "updatedTimestamp": 1694...,
                "version": 6
            }
        }
```

```
monitor_setup.is_constraint = False
monitor_setup.apply()
manager.save()
```

removes the `whylabs.constraint` tag