### PR TITLE
Refactor: add missingDatapoint to DatasetMetric

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.13
+current_version = 0.0.14
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whylabs-toolkit"
-version = "0.0.13"
+version = "0.0.14"
 description = "Whylabs CLI and Helpers package."
 authors = ["Anthony Naddeo <anthony.naddeo@gmail.com>", "Murilo Mendonca <murilommen@gmail.com>"]
 license = "Apache-2.0 license"

--- a/tests/monitor/manager/test_monitor_setup.py
+++ b/tests/monitor/manager/test_monitor_setup.py
@@ -246,12 +246,12 @@ def test_dataset_metrics_are_warned_on_setup(caplog):
 def test_dataset_matrix_if_metric_is_missing_datapoint(monitor_setup) -> None:
     monitor_setup.config = FixedThresholdsConfig(
         upper=0,
-        metric=DatasetMetric.missingDataPoint
+        metric=DatasetMetric.missing_data_point
     )
     monitor_setup.data_readiness_duration = "P1DT18H"
     monitor_setup.apply()
     
-    assert monitor_setup.analyzer.config.metric == DatasetMetric.missingDataPoint
+    assert monitor_setup.analyzer.config.metric == DatasetMetric.missing_data_point
     assert monitor_setup.analyzer.dataReadinessDuration == "P1DT18H"
     assert isinstance(monitor_setup.analyzer.targetMatrix, DatasetMatrix)
 

--- a/tests/monitor/manager/test_monitor_setup.py
+++ b/tests/monitor/manager/test_monitor_setup.py
@@ -246,12 +246,12 @@ def test_dataset_metrics_are_warned_on_setup(caplog):
 def test_dataset_matrix_if_metric_is_missing_datapoint(monitor_setup) -> None:
     monitor_setup.config = FixedThresholdsConfig(
         upper=0,
-        metric="missingDataPoint"
+        metric=DatasetMetric.missingDataPoint
     )
     monitor_setup.data_readiness_duration = "P1DT18H"
     monitor_setup.apply()
     
-    assert monitor_setup.analyzer.config.metric == "missingDataPoint"
+    assert monitor_setup.analyzer.config.metric == DatasetMetric.missingDataPoint
     assert monitor_setup.analyzer.dataReadinessDuration == "P1DT18H"
     assert isinstance(monitor_setup.analyzer.targetMatrix, DatasetMatrix)
 

--- a/whylabs_toolkit/monitor/models/analyzer/algorithms.py
+++ b/whylabs_toolkit/monitor/models/analyzer/algorithms.py
@@ -57,7 +57,7 @@ class DatasetMetric(str, Enum):
     regression_mse = "regression.mse"
     regression_mae = "regression.mae"
     regression_rmse = "regression.rmse"
-    
+
     # other metrics
     missingDataPoint = "missingDatapoint"
 

--- a/whylabs_toolkit/monitor/models/analyzer/algorithms.py
+++ b/whylabs_toolkit/monitor/models/analyzer/algorithms.py
@@ -59,7 +59,7 @@ class DatasetMetric(str, Enum):
     regression_rmse = "regression.rmse"
 
     # other metrics
-    missingDataPoint = "missingDatapoint"
+    missing_data_point = "missingDatapoint"
 
 
 class SimpleColumnMetric(str, Enum):

--- a/whylabs_toolkit/monitor/models/analyzer/algorithms.py
+++ b/whylabs_toolkit/monitor/models/analyzer/algorithms.py
@@ -57,6 +57,9 @@ class DatasetMetric(str, Enum):
     regression_mse = "regression.mse"
     regression_mae = "regression.mae"
     regression_rmse = "regression.rmse"
+    
+    # other metrics
+    missingDataPoint = "missingDatapoint"
 
 
 class SimpleColumnMetric(str, Enum):


### PR DESCRIPTION
Before this PR, users relied on defining a string-based metric with `FixedThresholdsConfig`. I've added the correct camelCase version to the `DatasetMetric` enum class, so that can prevent users from typos in the future.