### PR TITLE
Add support for disableTargetRollup analyzer option

### DIFF
--- a/whylabs_toolkit/monitor/manager/monitor_setup.py
+++ b/whylabs_toolkit/monitor/manager/monitor_setup.py
@@ -49,6 +49,7 @@ class MonitorSetup:
         self._exclude_columns: Optional[List[str]] = []
         self._monitor_tags: Optional[List[str]] = []
         self._analyzer_tags: Optional[List[str]] = []
+        self._analyzer_disable_target_rollup: Optional[bool] = None
         self._data_readiness_duration: Optional[str] = None
 
         self._prefill_properties()
@@ -92,6 +93,7 @@ class MonitorSetup:
             self._target_matrix = self.analyzer.targetMatrix
             self._analyzer_config = self.analyzer.config
             self._analyzer_tags = self.analyzer.tags
+            self._analyzer_disable_target_rollup = self.analyzer.disableTargetRollup
 
     @property
     def schedule(self) -> Optional[Union[CronSchedule, FixedCadenceSchedule]]:
@@ -175,6 +177,14 @@ class MonitorSetup:
         self._analyzer_tags = list(tags)
 
     @property
+    def disable_target_rollup(self) -> Optional[bool]:
+        return self._analyzer_disable_target_rollup == True
+
+    @disable_target_rollup.setter
+    def disable_target_rollup(self, disable_target_rollup: bool) -> None:
+        self._analyzer_disable_target_rollup = disable_target_rollup
+
+    @property
     def data_readiness_duration(self) -> Optional[str]:
         return self._data_readiness_duration
 
@@ -256,6 +266,7 @@ class MonitorSetup:
         self.analyzer = Analyzer(
             id=self.credentials.analyzer_id,
             displayName=self.credentials.analyzer_id,
+            disableTargetRollup=self._analyzer_disable_target_rollup,
             targetMatrix=self._target_matrix,
             dataReadinessDuration=self._data_readiness_duration,
             tags=self._analyzer_tags,

--- a/whylabs_toolkit/monitor/models/analyzer/analyzer.py
+++ b/whylabs_toolkit/monitor/models/analyzer/analyzer.py
@@ -66,6 +66,13 @@ class Analyzer(NoExtrasBaseModel):
         "This allows user to keep the configuration"
         "around without having to delete the analyzer config",
     )
+    disableTargetRollup: Optional[bool] = Field(
+        None,
+        description="For customers with individual profile storage enabled on their account (contact us), this "
+        "allows a user to monitor individual profiles without rolling them up. When enabled, analysis "
+        "will be timestamped 1:1 with the profile's dataset timestamp rather than being truncated "
+        "to the dataset granularity. ",
+    )
     targetMatrix: Union[ColumnMatrix, DatasetMatrix] = Field(
         description="A matrix for possible locations of the target",
         discriminator="type",

--- a/whylabs_toolkit/monitor/models/analyzer/targets.py
+++ b/whylabs_toolkit/monitor/models/analyzer/targets.py
@@ -68,3 +68,8 @@ class ColumnMatrix(_BaseMatrix):
         "evaluated AFTER the 'include' field and thus should be used with caution.",
         max_items=1000,
     )
+    profileId: Optional[str] = Field(
+        default=None,
+        description="The unique profile ID for the reference profile",
+        max_length=100,
+    )

--- a/whylabs_toolkit/monitor/schema/schema.json
+++ b/whylabs_toolkit/monitor/schema/schema.json
@@ -536,6 +536,12 @@
               }
             ]
           }
+        },
+        "profileId": {
+          "title": "ProfileId",
+          "description": "The unique profile ID for the reference profile",
+          "maxLength": 100,
+          "type": "string"
         }
       },
       "required": [
@@ -594,7 +600,8 @@
         "classification.precision",
         "classification.recall",
         "classification.accuracy",
-        "classification.auc",
+        "classification.fpr",
+        "classification.auroc",
         "regression.mse",
         "regression.mae",
         "regression.rmse"
@@ -649,7 +656,7 @@
     },
     "ThresholdType": {
       "title": "ThresholdType",
-      "description": "Threshold Type declaring the upper and lower bound.\n\n    By default an anomaly will be generated when the target is above or below the baseline\n    by the specified threshold.\n\n    If its only desirable to alert when the target is above the\n    baseline and not the other way around, specify upper for your ThresholdType.\n    ",
+      "description": "Threshold Type declaring the upper and lower bound.\n\nBy default an anomaly will be generated when the target is above or below the baseline\nby the specified threshold.\n\nIf its only desirable to alert when the target is above the\nbaseline and not the other way around, specify upper for your ThresholdType.",
       "enum": [
         "lower",
         "upper"
@@ -1414,6 +1421,9 @@
           "description": "Capping the minimum threshold by this value. This value only becomes effective if the calculated lower threshold from the calculation is lesser than this value",
           "type": "number"
         },
+        "thresholdType": {
+          "$ref": "#/definitions/ThresholdType"
+        },
         "type": {
           "title": "Type",
           "enum": [
@@ -1505,9 +1515,9 @@
           "default": "hellinger",
           "enum": [
             "hellinger",
-            "ks_test",
+            "jensenshannon",
             "kl_divergence",
-            "variation_distance"
+            "psi"
           ],
           "type": "string"
         },
@@ -1714,6 +1724,9 @@
           "description": "Capping the minimum threshold by this value. This value only becomes effective if the calculated lower threshold from the calculation is lesser than this value",
           "type": "number"
         },
+        "thresholdType": {
+          "$ref": "#/definitions/ThresholdType"
+        },
         "type": {
           "title": "Type",
           "enum": [
@@ -1726,9 +1739,7 @@
           "description": "The algorithm implementation for seasonal analysis",
           "default": "arima",
           "enum": [
-            "arima",
-            "rego",
-            "stastforecast"
+            "arima"
           ],
           "type": "string"
         },
@@ -1838,6 +1849,11 @@
         "disabled": {
           "title": "Disabled",
           "description": "Whether the analyzer is disabled. This allows user to keep the configurationaround without having to delete the analyzer config",
+          "type": "boolean"
+        },
+        "disableTargetRollup": {
+          "title": "Disabletargetrollup",
+          "description": "For customers with individual profile storage enabled on their account (contact us), this allows a user to monitor individual profiles without rolling them up. When enabled, analysis will be timestamped 1:1 with the profile's dataset timestamp rather than being truncated to the dataset granularity. ",
           "type": "boolean"
         },
         "targetMatrix": {


### PR DESCRIPTION
* Updates the monitor schema to the latest version
* Add support for `disableTargetRollup` analyzer option

Example:

```
from whylabs_toolkit.monitor.models import *
from whylabs_toolkit.monitor import MonitorSetup
from whylabs_toolkit.monitor import MonitorManager 

monitor_setup = MonitorSetup(monitor_id="courageous-firebrick-tiger-3073")
manager = MonitorManager(setup=monitor_setup)
monitor_setup.is_constraint = True
monitor_setup.disable_target_rollup = True
monitor_setup.apply()
manager.save()
```