### PR TITLE
added thresholdType as optional arg to SeasonalConfig

### DIFF
--- a/whylabs_toolkit/monitor/models/analyzer/algorithms.py
+++ b/whylabs_toolkit/monitor/models/analyzer/algorithms.py
@@ -307,6 +307,7 @@ class SeasonalConfig(_ThresholdBaseConfig):
         default=1.0,
         description="The multiplier factor for calculating upper bounds and lower bounds from the prediction.",
     )
+    thresholdType: Optional[ThresholdType]
 
 
 class DriftConfig(AlgorithmConfig):


### PR DESCRIPTION
`StddevConfig` has an optional `thresholdType` and so must `SeasonalConfig`. This PR addresses that